### PR TITLE
Excluded Fedora from EPEL install task

### DIFF
--- a/roles/netbootxyz/tasks/generate_disks_base.yml
+++ b/roles/netbootxyz/tasks/generate_disks_base.yml
@@ -16,7 +16,8 @@
     yum:
       name: epel-release
       state: present
-    when: ansible_os_family == "RedHat"
+    when:
+      - ansible_distribution == "CentOS"
 
   - name: Set var to bootloader of loop
     set_fact:

--- a/roles/netbootxyz/vars/redhat.yml
+++ b/roles/netbootxyz/vars/redhat.yml
@@ -9,3 +9,4 @@ netbootxyz_packages:
   - minizip-devel
   - syslinux
   - xz-devel
+  - make


### PR DESCRIPTION
Fedora includes most EPEL packages inside of their default repo, they also do not have a epel package,
including this "and not" statment will exlude Fedora from attempting to install epel